### PR TITLE
Make it optional to create workspaces from uploaded documents

### DIFF
--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -480,6 +480,7 @@ class AnythingLLM_API_Client:
 
     def _create_workspace_if_not_exists(self, workspace_name):
         # Check if CREATE_WORKSPACES is enabled and skip creation if not
+        create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
         if not create_workspaces:
             return
 

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -376,7 +376,7 @@ class AnythingLLM_API_Client:
         # -----------------------------
         try:
             # Check if CREATE_WORKSPACES is enabled and print log message if not
-            if not (os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")):
+            if not (os.getenv("CREATE_WORKSPACES", "true").lower() in ("1", "true", "yes")):
                 if self.verbose:
                     print(f"Skipping workspace creation because CREATE_WORKSPACES is not enabled.")
 
@@ -479,7 +479,7 @@ class AnythingLLM_API_Client:
 
     def _create_workspace_if_not_exists(self, workspace_name):
         # Check if CREATE_WORKSPACES is enabled and skip creation if not
-        if not (os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")):
+        if not (os.getenv("CREATE_WORKSPACES", "true").lower() in ("1", "true", "yes")):
             return
 
         try:

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -379,7 +379,7 @@ class AnythingLLM_API_Client:
             create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
             if not create_workspaces:
                 if self.verbose:
-                print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
+                    print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
 
             checked_workspaces = []
             workspaces_to_update = {}

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -376,8 +376,7 @@ class AnythingLLM_API_Client:
         # -----------------------------
         try:
             # Check if CREATE_WORKSPACES is enabled and print log message if not
-            create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
-            if not create_workspaces:
+            if not (os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")):
                 if self.verbose:
                     print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
 
@@ -480,8 +479,7 @@ class AnythingLLM_API_Client:
 
     def _create_workspace_if_not_exists(self, workspace_name):
         # Check if CREATE_WORKSPACES is enabled and skip creation if not
-        create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
-        if not create_workspaces:
+        if not (os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")):
             return
 
         try:

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -378,7 +378,7 @@ class AnythingLLM_API_Client:
             # Check if CREATE_WORKSPACES is enabled and print log message if not
             if not (os.getenv("CREATE_WORKSPACES", "true").lower() in ("1", "true", "yes")):
                 if self.verbose:
-                    print(f"Skipping workspace creation because CREATE_WORKSPACES is not enabled.")
+                    print(f"Skipping workspace creation because CREATE_WORKSPACES is disabled.")
 
             checked_workspaces = []
             workspaces_to_update = {}

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -375,6 +375,12 @@ class AnythingLLM_API_Client:
         # Then we make an API call for each workspace to update the embeddings.
         # -----------------------------
         try:
+            # Check if CREATE_WORKSPACES is enabled and print log message if not
+            create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
+            if not create_workspaces:
+                if self.verbose:
+                print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
+
             checked_workspaces = []
             workspaces_to_update = {}
             for workspace in list_of_new_embeddings:
@@ -473,13 +479,9 @@ class AnythingLLM_API_Client:
             print(f"Error deleting unused folders: {str(e)}")
 
     def _create_workspace_if_not_exists(self, workspace_name):
-        # Check if CREATE_WORKSPACES is enabled
-        create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
-
+        # Check if CREATE_WORKSPACES is enabled and skip creation if not
         if not create_workspaces:
-            if self.verbose:
-                print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
-            return  # exit without creating workspace
+            return
 
         try:
             if self.verbose: print(

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -473,6 +473,14 @@ class AnythingLLM_API_Client:
             print(f"Error deleting unused folders: {str(e)}")
 
     def _create_workspace_if_not_exists(self, workspace_name):
+        # Check if CREATE_WORKSPACES is enabled
+        create_workspaces = os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")
+
+        if not create_workspaces:
+            if self.verbose:
+                print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
+            return  # exit without creating workspace
+
         try:
             if self.verbose: print(
                 f" {workspace_name} did not exist as a workspace, so we create one"

--- a/check_for_files/tasks.py
+++ b/check_for_files/tasks.py
@@ -378,7 +378,7 @@ class AnythingLLM_API_Client:
             # Check if CREATE_WORKSPACES is enabled and print log message if not
             if not (os.getenv("CREATE_WORKSPACES", "false").lower() in ("1", "true", "yes")):
                 if self.verbose:
-                    print(f"Skipping workspace creation for '{workspace_name}' because CREATE_WORKSPACES is disabled.")
+                    print(f"Skipping workspace creation because CREATE_WORKSPACES is not enabled.")
 
             checked_workspaces = []
             workspaces_to_update = {}


### PR DESCRIPTION
This pull request defines an environment variable CREATE_WORKSPACES
- When CREATE_WORKSPACES = true, workspaces will be created automatically and documents are embedded
- When CREATE_WORKSPACES = false, workspace creation will be suppressed, and documents will just be uploaded

To preserve the current behavior, the default behavior if no environment variable is set is to create workspaces as usual.

Edit: Closes #5 